### PR TITLE
fix: make end() safe on non-connected clients to release the event loop

### DIFF
--- a/mqtt/client_base.go
+++ b/mqtt/client_base.go
@@ -91,6 +91,7 @@ type client struct {
 	vu       modules.VU
 	callChan chan func() error
 	stop     chan struct{}
+	stopOnce sync.Once
 
 	metrics *mqttMetrics
 
@@ -103,10 +104,15 @@ func newClient(log logrus.FieldLogger, vu modules.VU, metrics *mqttMetrics) *cli
 	c.vu = vu
 	c.callChan = make(chan func() error)
 	c.stop = make(chan struct{})
+	c.connOpts = new(connectOptions)
 
 	c.metrics = metrics
 
 	return c
+}
+
+func (c *client) stopLoop() {
+	c.stopOnce.Do(func() { close(c.stop) })
 }
 
 func (m *module) client(call sobek.ConstructorCall) *sobek.Object {

--- a/mqtt/client_connect.go
+++ b/mqtt/client_connect.go
@@ -192,7 +192,7 @@ func (c *client) disconnect() {
 		return
 	}
 
-	c.stop <- struct{}{}
+	c.stopLoop()
 
 	if c.pahoClient.IsConnected() {
 		c.pahoClient.Disconnect(0)

--- a/mqtt/client_end.go
+++ b/mqtt/client_end.go
@@ -10,10 +10,6 @@ type endOptions struct {
 }
 
 func (c *client) end(opts *endOptions) error {
-	if !c.isConnected() {
-		return errNotConnected
-	}
-
 	if opts == nil {
 		opts = new(endOptions)
 	}
@@ -25,15 +21,12 @@ func (c *client) end(opts *endOptions) error {
 	c.addCallMetrics("end", opts.Tags)
 
 	c.disconnect()
+	c.stopLoop()
 
 	return nil
 }
 
 func (c *client) endAsync(opts *endOptions) (*sobek.Promise, error) {
-	if !c.isConnected() {
-		return nil, errNotConnected
-	}
-
 	promise, resolve, reject := promises.New(c.vu)
 
 	go func() {

--- a/mqtt/client_loop.go
+++ b/mqtt/client_loop.go
@@ -7,6 +7,7 @@ func (c *client) loop() {
 	tq := taskqueue.New(c.vu.RegisterCallback)
 
 	defer tq.Close()
+	defer c.stopLoop()
 
 	for {
 		select {

--- a/mqtt/client_on.go
+++ b/mqtt/client_on.go
@@ -47,7 +47,7 @@ func (c *client) fire(event string, args ...sobek.Value) bool {
 
 	c.log.WithField("event", event).Debug("Queuing event handler")
 
-	c.callChan <- func() error {
+	call := func() error {
 		c.log.WithField("event", event).Debug("Firing event handler")
 
 		_, err := fn(sobek.Undefined(), args...)
@@ -55,7 +55,12 @@ func (c *client) fire(event string, args ...sobek.Value) bool {
 		return err
 	}
 
-	return true
+	select {
+	case c.callChan <- call:
+		return true
+	case <-c.stop:
+		return false
+	}
 }
 
 func (c *client) messageHandler(_ paho.Client, msg paho.Message) {

--- a/mqtt/testdata/end_without_connect_test.cjs
+++ b/mqtt/testdata/end_without_connect_test.cjs
@@ -1,0 +1,22 @@
+const mqtt = require("k6/x/mqtt")
+const assert = require("k6/x/assert")
+
+var endHandlerCalled = false
+
+module.exports = () => {
+  const client = new mqtt.Client()
+
+  client.on("end", () => {
+    endHandlerCalled = true
+  })
+
+  assert.false(client.connected, "Client should not be connected initially")
+
+  client.end()
+
+  assert.false(client.connected, "Client should not be connected after end call")
+}
+
+module.exports.teardown = () => {
+  assert.true(endHandlerCalled, "End handler was not called")
+}


### PR DESCRIPTION
Fix #74

`end()` and `endAsync()` no longer fail with `not connected` on a client that
never connected (or whose connect attempt failed). Instead they stop the
client's event dispatch loop, releasing the VU event loop — so an iteration
can finish cleanly after a failed `connect()` instead of hanging until the
scenario `maxDuration`.

This also matches MQTT.js semantics, which the README cites as the design
reference for this API: MQTT.js `end()` can be called regardless of
connection state, never throws "not connected", and always emits `end`.

Changes:

- `client_base.go`: add `stopLoop()`, an idempotent (`sync.Once`) `close` of
  the stop channel; initialize `connOpts` in the constructor (the metrics tag
  helpers dereference it on the newly reachable path)
- `client_connect.go`: `disconnect()` uses `stopLoop()` instead of a blocking
  send on the stop channel
- `client_end.go`: drop the `errNotConnected` guard from
  `end()`/`endAsync()`; `end()` stops the dispatch loop even when there is
  nothing to disconnect
- `client_on.go`: `fire()` selects on the stop channel while queueing, so
  paho callback goroutines cannot block forever once the loop has stopped
- `client_loop.go`: `defer c.stopLoop()` so the `ctx.Done()` exit path also
  unblocks `fire()`
- `mqtt/testdata/end_without_connect_test.cjs`: regression test — fails with
  `GoError: not connected` before this change

Verified:

- `go test ./...` (including the new regression test) and the full suite
  under `-race`: pass
- golangci-lint with the k6-ci config: 0 issues; `gosec` and `govulncheck`:
  clean
- With a k6 binary built from this branch: failed connect (connection
  refused / dial timeout / TLS error) + `client.end()` in the `error` handler
  completes the iteration immediately (previously `GoError: not connected`,
  or a hang until `maxDuration` if `end()` was not called); happy path
  against a real broker (EMQX 6.1.3) unchanged; double `end()` is a no-op
  (the `end` event fires once; note the `mqtt_calls` counter still counts
  each `end()` call)
