### PR TITLE
fix: end the client in TestClientConnectBlacklisted

### DIFF
--- a/mqtt/client_connect_test.go
+++ b/mqtt/client_connect_test.go
@@ -134,5 +134,7 @@ func TestClientConnectBlacklisted(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "is in a blacklisted range")
 
+	require.NoError(t, client.end(nil))
+
 	runtime.EventLoop.WaitOnRegistered()
 }


### PR DESCRIPTION
Fix #67

`TestClientConnectBlacklisted` creates a client and never ends it, so the client's dispatch loop keeps the event loop registered and the final `WaitOnRegistered()` can wait forever, depending on goroutine scheduling. That is what times out in the failing CI runs (details in #67).

Calling `end()` before `WaitOnRegistered()` releases the loop deterministically. With this change, `go test -race -run TestClientConnectBlacklisted -count=50` limited to 2 CPUs passes 50/50 in about a second. Without it, the same setup hits the timeout panic seen in CI.
