### PR TITLE
fix: avoid panic on reconnect() without a prior connection

### DIFF
--- a/mqtt/client_connect_test.go
+++ b/mqtt/client_connect_test.go
@@ -138,3 +138,25 @@ func TestClientConnectBlacklisted(t *testing.T) {
 
 	runtime.EventLoop.WaitOnRegistered()
 }
+
+func TestClientReconnectWithoutConnect(t *testing.T) {
+	t.Parallel()
+
+	runtime := newTestRuntime(t)
+	mm := newMqttMetrics(runtime.VU)
+	logger := runtime.VU.InitEnv().Logger
+
+	runtime.MoveToVUContext(newTestVUState(t))
+
+	client := newTestClient(t, logger, runtime.VU, mm)
+
+	err := runtime.EventLoop.Start(func() error {
+		return client.reconnect()
+	})
+
+	require.Error(t, err)
+
+	require.NoError(t, client.end(nil))
+
+	runtime.EventLoop.WaitOnRegistered()
+}

--- a/mqtt/client_metrics.go
+++ b/mqtt/client_metrics.go
@@ -47,8 +47,8 @@ func (c *client) tags() *metrics.TagSet {
 			tags = tags.With("client_id", cid)
 		}
 
-		if url := opts.Servers()[0]; url != nil {
-			tags = tags.With("url", url.String())
+		if c.url != "" {
+			tags = tags.With("url", c.url)
 		}
 	}
 


### PR DESCRIPTION
Fix #78

`reconnect()` (and `reconnectAsync()`) call `connectExecute()` directly, without the address validation that `connect()` runs first. When the client has no URL set (called before any `connect()`, or after a `connect()` that failed address validation), `newPahoClient()` builds a paho client with no brokers. The failed `Connect()` then emits an error metric, and `tags()` panics on `opts.Servers()[0]` because the server list is empty. This is a Go runtime panic, so it cannot be caught from the script and it aborts the whole run.

This sets the `url` tag from the URL the client already stores (`c.url`) instead of reading it back from the paho client. The connect-failure path already tags with `c.url`, so the `url` tag is now consistent across the success and failure paths. With this change the failed reconnect surfaces a catchable error (`no servers defined to connect to`) and the iteration finishes.

Added `TestClientReconnectWithoutConnect`, which panics without this change and passes with it. The existing suite passes under `-race`.
